### PR TITLE
Allow 0xFF padding in 'End' option

### DIFF
--- a/dhcpv4/options.go
+++ b/dhcpv4/options.go
@@ -156,8 +156,10 @@ func (o Options) fromBytesCheckEnd(data []byte, checkEndOption bool) error {
 	}
 
 	// Any bytes left must be padding.
+	var pad uint8
 	for buf.Len() >= 1 {
-		if buf.Read8() != optPad {
+		pad = buf.Read8()
+		if pad != optPad && pad != optEnd {
 			return ErrInvalidOptions
 		}
 	}


### PR DESCRIPTION
After investigation on DHCP relaying with BDCOM P3608 GPON OLT switches, i found that 'End' option is not always padded with 0x00, but for some packet is padded by same 0xFF (End) option.

DHCPv4 fails to parse such type of packets and throws an "Invalid options" error. But Wireshark says that all is just fine with 0xFF padding.

This commit allows to use 0xFF/0x00 End option padding instead of strict 0x00. This allows BDCOM switches relaying mechanism to work with package.